### PR TITLE
ensure acert leaves list prints the correct authority

### DIFF
--- a/cmd/leaves/list/command.go
+++ b/cmd/leaves/list/command.go
@@ -42,7 +42,7 @@ func Command() *cobra.Command {
 
 			for _, identity := range identities {
 
-				authority := certificates.Fingerprint(identity.Authorities[1])
+				authority := certificates.Fingerprint(identity.Authorities[0])
 				expiration := certificates.Expiration(identity.Certificate)
 				fingerprint := certificates.Fingerprint(identity.Certificate)
 				name := certificates.CommonName(identity.Certificate)


### PR DESCRIPTION
@tilleryd, this make the output a lot more clear for leaf lists:

For authorities:
```
➜  acert authorities list
92d1241e684c	greymatter-1.3 (Intermediate)	2030-09-23 19:59:10 +0000 UTC
```
With the current implementation:
```
➜  acert leaves list
845186a24ede	32c5f74058b1	leaf	2030-09-23 19:59:38 +0000 UTC
```
With this implementation:
```
➜  ./bin/acert leaves list
845186a24ede	92d1241e684c	leaf	2030-09-23 19:59:38 +0000 UTC
```
Note that the authority fingerprint now matches the fingerprint provided to issue the certificate.