### PR TITLE
improve errors on create and help on issue

### DIFF
--- a/cmd/authorities/create/command.go
+++ b/cmd/authorities/create/command.go
@@ -33,6 +33,7 @@ func Command() *cobra.Command {
 	command := &cobra.Command{
 		Use:   "create",
 		Short: "Create an authority",
+		Args: cobra.ExactArgs(0),
 		RunE: func(command *cobra.Command, args []string) error {
 
 			viper.BindPFlag("commonName", command.Flags().Lookup("commonName"))

--- a/cmd/authorities/issue/command.go
+++ b/cmd/authorities/issue/command.go
@@ -31,7 +31,7 @@ import (
 func Command() *cobra.Command {
 
 	command := &cobra.Command{
-		Use:   "issue",
+		Use:   "issue FINGERPRINT",
 		Short: "Issue a certificate",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(command *cobra.Command, args []string) error {


### PR DESCRIPTION
@tilleryd, this provides two minor usability improvements.

First, providing any arguments to `acert authorities create` will now result in an error (helps to prevent accidental and undetectable misuse).

```
➜  ./bin/acert authorities create orange
Error: accepts 0 arg(s), received 1
Usage:
  acert authorities create [flags]

Flags:
  -n, --commonName string           common name for the authority (default "Acert")
  -c, --country string              two letter country code for the authority (default "US")
  -e, --expires duration            expiration time for the authority (default 87600h0m0s)
  -h, --help                        help for create
  -l, --locality string             locality for the authority (default "Alexandria")
  -o, --organization string         organization for the authority (default "Decipher Technology Studios")
  -u, --organizationalUnit string   organizational unit for the authority (default "Engineering")
  -p, --postalCode string           postal code for the authority
  -s, --state string                state for the authority (default "Virginia")
  -a, --streetAddress string        street address for the authority

accepts 0 arg(s), received 1
```

Second, example usage for `acert authorities issue` now includes the parameter `FINGERPRINT` as that was omitted previously:
```
➜  ./bin/acert authorities issue -h                     
Issue a certificate

Usage:
  acert authorities issue FINGERPRINT [flags]

Flags:
  -n, --commonName string           common name for the authority (default "Acert")
  -c, --country string              two letter country code for the authority (default "US")
  -e, --expires duration            expiration time for the authority (default 87600h0m0s)
  -h, --help                        help for issue
  -l, --locality string             locality for the authority (default "Alexandria")
  -o, --organization string         organization for the authority (default "Decipher Technology Studios")
  -u, --organizationalUnit string   organizational unit for the authority (default "Engineering")
  -p, --postalCode string           postal code for the authority
  -s, --state string                state for the authority (default "Virginia")
  -a, --streetAddress string        street address for the authority
```