### PR TITLE
remove extraneous error printing

### DIFF
--- a/main.go
+++ b/main.go
@@ -15,7 +15,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/greymatter-io/acert/cmd"
@@ -24,7 +23,6 @@ import (
 func main() {
 	err := cmd.Acert().Execute()
 	if err != nil {
-		fmt.Println(err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
minor tweak to prevent logging command errors twice since cobra does this already.  this turns the output from:
```
➜  ./bin/acert authorities create orange
Error: accepts 0 arg(s), received 1
Usage:
  acert authorities create [flags]

Flags:
  -n, --commonName string           common name for the authority (default "Acert")
  -c, --country string              two letter country code for the authority (default "US")
  -e, --expires duration            expiration time for the authority (default 87600h0m0s)
  -h, --help                        help for create
  -l, --locality string             locality for the authority (default "Alexandria")
  -o, --organization string         organization for the authority (default "Decipher Technology Studios")
  -u, --organizationalUnit string   organizational unit for the authority (default "Engineering")
  -p, --postalCode string           postal code for the authority
  -s, --state string                state for the authority (default "Virginia")
  -a, --streetAddress string        street address for the authority

accepts 0 arg(s), received 1
```
to
```
➜  ./bin/acert authorities create orange
Error: accepts 0 arg(s), received 1
Usage:
  acert authorities create [flags]

Flags:
  -n, --commonName string           common name for the authority (default "Acert")
  -c, --country string              two letter country code for the authority (default "US")
  -e, --expires duration            expiration time for the authority (default 87600h0m0s)
  -h, --help                        help for create
  -l, --locality string             locality for the authority (default "Alexandria")
  -o, --organization string         organization for the authority (default "Decipher Technology Studios")
  -u, --organizationalUnit string   organizational unit for the authority (default "Engineering")
  -p, --postalCode string           postal code for the authority
  -s, --state string                state for the authority (default "Virginia")
  -a, --streetAddress string        street address for the authority

```
Note that the error is now only logged on the first line of output, not the first and last.